### PR TITLE
update min_dist

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,6 @@ Refer to the [Usage Instructions](./Tutorials/README.md) for more detailed examp
 
 #### Tab Completion Support
 
----
-
 `gpumdkit.sh` provides optional Bash `Tab` completion to enhance the command-line experience. This feature allows you to auto-complete primary options (e.g., `-h`, `-plt`, `-calc`) and their secondary parameters (e.g., `thermo`, `train`) by pressing the `Tab` key.
 
 ##### Usage Examples

--- a/Scripts/analyzer/get_min_dist.py
+++ b/Scripts/analyzer/get_min_dist.py
@@ -1,7 +1,7 @@
 import sys
 import numpy as np
 from ase.io import read
-from scipy.spatial.distance import pdist
+from scipy.spatial.distance import pdist, squareform
 
 # Read the file name from command line arguments
 file_name = sys.argv[1]
@@ -9,15 +9,62 @@ file_name = sys.argv[1]
 # Read all frames from the extxyz file
 frames = read(file_name, index=':')
 
-min_distance = float('inf')
+# Get the original order of atom types from the first frame
+first_frame_symbols = frames[0].get_chemical_symbols()
+# Get unique symbols while preserving order
+unique_symbols = []
+[unique_symbols.append(s) for s in first_frame_symbols if s not in unique_symbols]
+
+# Dictionary to store minimum distances between atom pairs
+min_distances = {}
+# Variable to track overall minimum distance
+overall_min_distance = float('inf')
 
 # Iterate over each frame
 for frame in frames:
-    # Get atomic positions
+    # Get atomic positions and chemical symbols
     positions = frame.get_positions()
-    # Compute distances between all pairs of atoms
-    distances = pdist(positions)
-    # Update the minimum distance
-    min_distance = min(min_distance, np.min(distances))
+    symbols = frame.get_chemical_symbols()
 
-print(f' Minimum interatomic distance: {min_distance:.3f} Å')
+    # Compute pairwise distances
+    distances = squareform(pdist(positions))
+
+    # Calculate minimum distance for each atom pair type
+    for i, sym1 in enumerate(unique_symbols):
+        for sym2 in unique_symbols[i:]:  # Start from i to include same-type pairs
+            # Get indices of atoms for both types
+            idx1 = [i for i, s in enumerate(symbols) if s == sym1]
+            idx2 = [i for i, s in enumerate(symbols) if s == sym2]
+
+            # Get all distances between these atom types
+            pair_distances = distances[np.ix_(idx1, idx2)]
+
+            # Exclude zero distances (same atom) if sym1 == sym2
+            if sym1 == sym2:
+                pair_distances = pair_distances[pair_distances > 0]
+
+            # Update minimum distance if we have valid distances
+            if len(pair_distances) > 0:
+                min_dist = np.min(pair_distances)
+                pair_key = f"{sym1}-{sym2}"
+                if pair_key not in min_distances or min_dist < min_distances[pair_key]:
+                    min_distances[pair_key] = min_dist
+                # Update overall minimum distance
+                overall_min_distance = min(overall_min_distance, min_dist)
+
+# Print results in table format
+print(" +---------------------------+")
+print(" |   PBC ignored for speed   |")
+print(" | use -min_dist_pbc for PBC |")
+print(" +---------------------------+")
+print(" Minimum interatomic distances:")
+print(" +---------------------------+")
+print(" | Atom Pair |  Distance (Å) |")
+print(" +---------------------------+")
+for i, sym1 in enumerate(unique_symbols):
+    for sym2 in unique_symbols[i:]:
+        pair = f"{sym1}-{sym2}"
+        distance = min_distances[pair]
+        print(f" |   {pair:<6}  |     {distance:>5.3f}     |")
+print(" +---------------------------+")
+print(f" Overall min_distance: {overall_min_distance:.3f} Å")

--- a/Scripts/analyzer/get_min_dist_pbc.py
+++ b/Scripts/analyzer/get_min_dist_pbc.py
@@ -8,15 +8,56 @@ file_name = sys.argv[1]
 # Read all frames from the extxyz file
 frames = read(file_name, index=':')
 
-min_distance = float('inf')
+# Get the original order of atom types from the first frame
+first_frame_symbols = frames[0].get_chemical_symbols()
+# Get unique symbols while preserving order
+unique_symbols = []
+[unique_symbols.append(s) for s in first_frame_symbols if s not in unique_symbols]
+
+# Dictionary to store minimum distances between atom pairs
+min_distances = {}
+# Variable to track overall minimum distance
+overall_min_distance = float('inf')
 
 # Iterate over each frame
 for frame in frames:
+    # Get atomic positions and chemical symbols
+    symbols = frame.get_chemical_symbols()
     # Get all distances between atoms considering PBC
     distances = frame.get_all_distances(mic=True)
-    # Exclude self-distances (diagonal elements) by setting them to a large value
-    np.fill_diagonal(distances, float('inf'))
-    # Update the minimum distance
-    min_distance = min(min_distance, np.min(distances))
+    
+    # Calculate minimum distance for each atom pair type
+    for i, sym1 in enumerate(unique_symbols):
+        for sym2 in unique_symbols[i:]:
+            # Get indices of atoms for both types
+            idx1 = [i for i, s in enumerate(symbols) if s == sym1]
+            idx2 = [i for i, s in enumerate(symbols) if s == sym2]
+            
+            # Get all distances between these atom types
+            pair_distances = distances[np.ix_(idx1, idx2)]
+            
+            # Exclude zero distances (same atom) if sym1 == sym2
+            if sym1 == sym2:
+                pair_distances = pair_distances[pair_distances > 0]
+            
+            # Update minimum distance if we have valid distances
+            if len(pair_distances) > 0:
+                min_dist = np.min(pair_distances)
+                pair_key = f"{sym1}-{sym2}"
+                if pair_key not in min_distances or min_dist < min_distances[pair_key]:
+                    min_distances[pair_key] = min_dist
+                # Update overall minimum distance
+                overall_min_distance = min(overall_min_distance, min_dist)
 
-print(f' Minimum interatomic distance: {min_distance:.3f} Å')
+# Print results in table format
+print(" Minimum interatomic distances (with PBC):")
+print(" +---------------------------+")
+print(" | Atom Pair |  Distance (Å) |")
+print(" +---------------------------+")
+for i, sym1 in enumerate(unique_symbols):
+    for sym2 in unique_symbols[i:]:
+        pair = f"{sym1}-{sym2}"
+        distance = min_distances[pair]
+        print(f" |   {pair:<6}  |     {distance:>5.3f}     |")
+print(" +---------------------------+")
+print(f" Overall min_distance: {overall_min_distance:.3f} Å")

--- a/gpumdkit.sh
+++ b/gpumdkit.sh
@@ -12,7 +12,7 @@ if [ -z "$GPUMD_path" ] || [ -z "$GPUMDkit_path" ]; then
     exit 1
 fi
 
-VERSION="1.2.0 (dev) (2025-04-04)"
+VERSION="1.2.1 (dev) (2025-04-09)"
 
 #--------------------- function 1 format conversion ----------------------
 # These functions are used to convert the format of the files


### PR DESCRIPTION
This pull request includes several updates and enhancements across multiple scripts and documentation. The most significant changes involve improvements to the calculation of minimum interatomic distances, both with and without periodic boundary conditions (PBC), and a minor version update in the `gpumdkit.sh` script.

### Enhancements to minimum interatomic distance calculations:

* [`Scripts/analyzer/get_min_dist.py`](diffhunk://#diff-824cf5eec9daf2c87fe24b458d274262f294bbb8733ae54b300bfb01e6a40f68L4-R70): Enhanced the script to calculate minimum distances for each atom pair type and print results in a table format. The overall minimum distance is also tracked and displayed.
* [`Scripts/analyzer/get_min_dist_pbc.py`](diffhunk://#diff-73834ed8e4779b2e96c531943637c4d38f270973dc526d0089327e966636e950L11-R63): Improved the script to calculate minimum distances considering PBC for each atom pair type, and print results in a table format. The overall minimum distance is also tracked and displayed.

### Minor updates:

* [`gpumdkit.sh`](diffhunk://#diff-495d99f601815741384d8018da45abb96f2f308c9cf48ca78a7d9f579b2cf07aL15-R15): Updated the version from "1.2.0 (dev) (2025-04-04)" to "1.2.1 (dev) (2025-04-09)".

### Documentation:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L166-L167): Removed extraneous blank lines in the Tab Completion Support section to improve readability.