### PR TITLE
Update plt scripts

### DIFF
--- a/Scripts/analyzer/time_consuming_nep.sh
+++ b/Scripts/analyzer/time_consuming_nep.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# Get total steps from nep.in (still needed for remaining time calculation)
+# Get total steps from nep.in
 total_steps=$(grep 'generation' "nep.in" | awk '{print $2}')
 
-# Get the last output step from loss.out (for initializing current step)
+# Get the last output step from loss.out
 current_step=$(tail -1 "loss.out" | awk '{print $1}')
 
 # Initialize variables for time and step tracking
@@ -12,13 +12,13 @@ first_step=0
 first_read=true
 
 # Print table header with borders
-echo "+-----------------+-----------+-----------------+"
-echo "|       Step      | Time Diff |    Time Left    |"
-echo "+-----------------+-----------+-----------------+"
+echo "+-----------------+-----------+-----------------+---------------------+"
+echo "|       Step      | Time Diff |    Time Left    |    Finish Time      |"
+echo "+-----------------+-----------+-----------------+---------------------+"
 
 # Read loss.out file in real-time
 tail -1f "loss.out" | while read line; do
-  # Extract the step from the current line (assuming step is the first column)
+  # Extract the step from the current line
   step=$(echo "$line" | awk '{print $1}')
 
   # Get current timestamp
@@ -55,11 +55,11 @@ tail -1f "loss.out" | while read line; do
   minutes=$(((remaining_time % 3600) / 60))
   seconds=$((remaining_time % 60))
 
-  # Prepare centered values
-  step_val="$current_step"
-  time_val="$time_diff s"
-  remain_val="$hours h $minutes m $seconds s"
+  # Calculate finish time (current time + remaining time)
+  finish_timestamp=$((timestamp + remaining_time))
+  finish_time=$(date -d "@$finish_timestamp" "+%Y-%m-%d %H:%M:%S")
 
-  # Output data in table format with centered values
-  printf "| %-15s | %-9s | %-15s |\n" "$current_step" "$time_diff s" "$hours h $minutes m $seconds s"
+  # Output data in table format
+  printf "| %-15s | %-9s | %-15s | %-19s |\n" \
+    "$current_step" "$time_diff s" "$hours h $minutes m $seconds s" "$finish_time"
 done

--- a/Scripts/plt_scripts/plt_dimer.py
+++ b/Scripts/plt_scripts/plt_dimer.py
@@ -88,4 +88,11 @@ plt.tight_layout()
 if len(sys.argv) > 4 and sys.argv[4] == 'save':
     plt.savefig('dimer.png', dpi=300)
 else:
-    plt.show()
+    # Check if the current backend is non-interactive
+    from matplotlib import get_backend
+    if get_backend().lower() in ['agg', 'cairo', 'pdf', 'ps', 'svg']:
+        print("Unable to display the plot due to the non-interactive backend.")
+        print("The plot has been automatically saved as 'dimer.png'.")
+        plt.savefig('dimer.png', dpi=300)
+    else:
+        plt.show()

--- a/Scripts/plt_scripts/plt_force_errors.py
+++ b/Scripts/plt_scripts/plt_force_errors.py
@@ -131,6 +131,13 @@ ax6.set_title(r'The CDF of $\delta_{\theta}$')
 plt.tight_layout(pad=1.0)
 
 if len(sys.argv) > 1 and sys.argv[1] == 'save':
-    plt.savefig('./force_errors.png', dpi=200)
+    plt.savefig('force_errors.png', dpi=300)
 else:
-    plt.show()
+    # Check if the current backend is non-interactive
+    from matplotlib import get_backend
+    if get_backend().lower() in ['agg', 'cairo', 'pdf', 'ps', 'svg']:
+        print("Unable to display the plot due to the non-interactive backend.")
+        print("The plot has been automatically saved as 'force_errors.png'.")
+        plt.savefig('force_errors.png', dpi=300)
+    else:
+        plt.show()

--- a/Scripts/plt_scripts/plt_msd.py
+++ b/Scripts/plt_scripts/plt_msd.py
@@ -52,4 +52,11 @@ plt.tight_layout()
 if len(sys.argv) > 1 and sys.argv[1] == 'save':
     plt.savefig('msd.png', dpi=300)
 else:
-    plt.show()
+    # Check if the current backend is non-interactive
+    from matplotlib import get_backend
+    if get_backend().lower() in ['agg', 'cairo', 'pdf', 'ps', 'svg']:
+        print("Unable to display the plot due to the non-interactive backend.")
+        print("The plot has been automatically saved as 'msd.png'.")
+        plt.savefig('msd.png', dpi=300)
+    else:
+        plt.show()

--- a/Scripts/plt_scripts/plt_nep_prediction_results.py
+++ b/Scripts/plt_scripts/plt_nep_prediction_results.py
@@ -86,4 +86,11 @@ plt.tight_layout()
 if len(sys.argv) > 1 and sys.argv[1] == 'save':
     plt.savefig('prediction.png', dpi=300)
 else:
-    plt.show()
+    # Check if the current backend is non-interactive
+    from matplotlib import get_backend
+    if get_backend().lower() in ['agg', 'cairo', 'pdf', 'ps', 'svg']:
+        print("Unable to display the plot due to the non-interactive backend.")
+        print("The plot has been automatically saved as 'prediction.png'.")
+        plt.savefig('prediction.png', dpi=300)
+    else:
+        plt.show()

--- a/Scripts/plt_scripts/plt_nep_restart.py
+++ b/Scripts/plt_scripts/plt_nep_restart.py
@@ -35,6 +35,13 @@ fig.subplots_adjust(top=0.918,bottom=0.142,left=0.139,right=0.975,hspace=0.0,wsp
 
 # Show the plot
 if len(sys.argv) > 1 and sys.argv[1] == 'save':
-    plt.savefig('./nep_restart.png', dpi=300)
+    plt.savefig('nep_restart.png', dpi=300)
 else:
-    plt.show()
+    # Check if the current backend is non-interactive
+    from matplotlib import get_backend
+    if get_backend().lower() in ['agg', 'cairo', 'pdf', 'ps', 'svg']:
+        print("Unable to display the plot due to the non-interactive backend.")
+        print("The plot has been automatically saved as 'nep_restart.png'.")
+        plt.savefig('nep_restart.png', dpi=300)
+    else:
+        plt.show()

--- a/Scripts/plt_scripts/plt_nep_thermo.py
+++ b/Scripts/plt_scripts/plt_nep_thermo.py
@@ -189,6 +189,13 @@ if num_columns == 18:
 plt.tight_layout()
 
 if len(sys.argv) > 1 and sys.argv[1] == 'save':
-    plt.savefig('./thermo.png', dpi=150)
+    plt.savefig('thermo.png', dpi=150)
 else:
-    plt.show()
+    # Check if the current backend is non-interactive
+    from matplotlib import get_backend
+    if get_backend().lower() in ['agg', 'cairo', 'pdf', 'ps', 'svg']:
+        print("Unable to display the plot due to the non-interactive backend.")
+        print("The plot has been automatically saved as 'thermo.png'.")
+        plt.savefig('thermo.png', dpi=300)
+    else:
+        plt.show()

--- a/Scripts/plt_scripts/plt_nep_train_results.py
+++ b/Scripts/plt_scripts/plt_nep_train_results.py
@@ -96,4 +96,11 @@ plt.tight_layout()
 if len(sys.argv) > 1 and sys.argv[1] == 'save':
     plt.savefig('train.png', dpi=300)
 else:
-    plt.show()
+    # Check if the current backend is non-interactive
+    from matplotlib import get_backend
+    if get_backend().lower() in ['agg', 'cairo', 'pdf', 'ps', 'svg']:
+        print("Unable to display the plot due to the non-interactive backend.")
+        print("The plot has been automatically saved as 'train.png'.")
+        plt.savefig('train.png', dpi=300)
+    else:
+        plt.show()

--- a/Scripts/plt_scripts/plt_nep_train_test.py
+++ b/Scripts/plt_scripts/plt_nep_train_test.py
@@ -97,4 +97,11 @@ fig.subplots_adjust(top=0.968, bottom=0.16, left=0.086, right=0.983, hspace=0.2,
 if len(sys.argv) > 1 and sys.argv[1] == 'save':
     plt.savefig('train_test.png', dpi=300)
 else:
-    plt.show()
+    # Check if the current backend is non-interactive
+    from matplotlib import get_backend
+    if get_backend().lower() in ['agg', 'cairo', 'pdf', 'ps', 'svg']:
+        print("Unable to display the plot due to the non-interactive backend.")
+        print("The plot has been automatically saved as 'train_test.png'.")
+        plt.savefig('train_test.png', dpi=300)
+    else:
+        plt.show()

--- a/Scripts/plt_scripts/plt_sdc.py
+++ b/Scripts/plt_scripts/plt_sdc.py
@@ -34,4 +34,11 @@ plt.tight_layout()
 if len(sys.argv) > 1 and sys.argv[1] == 'save':
     plt.savefig('sdc.png', dpi=300)
 else:
-    plt.show()
+    # Check if the current backend is non-interactive
+    from matplotlib import get_backend
+    if get_backend().lower() in ['agg', 'cairo', 'pdf', 'ps', 'svg']:
+        print("Unable to display the plot due to the non-interactive backend.")
+        print("The plot has been automatically saved as 'sdc.png'.")
+        plt.savefig('sdc.png', dpi=300)
+    else:
+        plt.show()

--- a/Scripts/plt_scripts/plt_vac.py
+++ b/Scripts/plt_scripts/plt_vac.py
@@ -35,4 +35,11 @@ plt.tight_layout()
 if len(sys.argv) > 1 and sys.argv[1] == 'save':
     plt.savefig('vac.png')
 else:
-    plt.show()
+    # Check if the current backend is non-interactive
+    from matplotlib import get_backend
+    if get_backend().lower() in ['agg', 'cairo', 'pdf', 'ps', 'svg']:
+        print("Unable to display the plot due to the non-interactive backend.")
+        print("The plot has been automatically saved as 'vac.png'.")
+        plt.savefig('vac.png', dpi=300)
+    else:
+        plt.show()

--- a/gpumdkit.sh
+++ b/gpumdkit.sh
@@ -12,7 +12,7 @@ if [ -z "$GPUMD_path" ] || [ -z "$GPUMDkit_path" ]; then
     exit 1
 fi
 
-VERSION="1.2.3 (dev) (2025-04-18)"
+VERSION="1.2.3 (dev) (2025-04-22)"
 
 #--------------------- function 1 format conversion ----------------------
 # These functions are used to convert the format of the files


### PR DESCRIPTION
This pull request introduces several enhancements and fixes across multiple script files. The most significant changes include updates to improve time tracking in a shell script, better handling of non-interactive backends in plotting scripts, and minor version updates. Below is a categorized summary of the most important changes:

### Enhancements to Time Tracking in Shell Script
* Updated `Scripts/analyzer/time_consuming_nep.sh` to include a new column for finish time in the output table, calculated as the current time plus the remaining time. [[1]](diffhunk://#diff-32c3f8da321f37ca2d77167bd2187f798a6b2418c3b6f5d8007ff6fe0859e72dL15-R21) [[2]](diffhunk://#diff-32c3f8da321f37ca2d77167bd2187f798a6b2418c3b6f5d8007ff6fe0859e72dL58-R64)

### Improved Plotting Behavior for Non-Interactive Backends
* Added checks for non-interactive backends in multiple plotting scripts (`plt_dimer.py`, `plt_force_errors.py`, `plt_msd.py`, `plt_nep_prediction_results.py`, `plt_nep_restart.py`, `plt_nep_thermo.py`, `plt_nep_train_results.py`, `plt_nep_train_test.py`, `plt_sdc.py`, `plt_vac.py`). If a non-interactive backend is detected, the plot is automatically saved, and a message is displayed to inform the user. [[1]](diffhunk://#diff-6f07bdd15d3917af725d2091ad3aadcaf2dcf68e47bbff3cfd7b1f7ba6928e38R90-R96) [[2]](diffhunk://#diff-87ab4568481ee59bf85aa107bf4184c68e0d846785cee4d3ac688b93beeb3723L134-R141) [[3]](diffhunk://#diff-f93be7f3b0a9f30eb548da3432484f9b4b1831b3fa7494e2452974390d78d7c8R54-R60) [[4]](diffhunk://#diff-39feead320bc6b8094b1817d2471c9f9a8fc1982874b217f7fe8cf93c531b992R88-R94) [[5]](diffhunk://#diff-c662cb8013c1f7690c8ae993f24b346f5e5082d3b3359f984dc23331a656d02aL38-R45) [[6]](diffhunk://#diff-890683b6baa5c76aaaab5e0faaa2b52d1b6d5669b8ea081f7327e5752bf4ca6fL192-R199) [[7]](diffhunk://#diff-f7a363db5fe1c958b4179173f80d1c21fd87fc400337a1226dce660b8a8d05c8R98-R104) [[8]](diffhunk://#diff-7ebf473427ce31d56e0652e78ef991fb1fc810428cb09a117f5d97638cc84408R99-R105) [[9]](diffhunk://#diff-6d5b2aab92baa1cf0bc9210bf6000e088e6f61a7770320ce7180c30b4d2e8ef2R36-R42) [[10]](diffhunk://#diff-6ae6737fae9fa9e6feb87880f9e5e93af68a2862ef590218995bf10ca0790dffR37-R43)

### Minor Updates
* Updated the version information in `gpumdkit.sh` to reflect the new date.