### PR TITLE
add -cif2pos and -cif2exyz

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <a href="https://zhyan0603.github.io/GPUMDkit">
   <img src="./docs/Gallery/gpumdkit_logo.png" width="25%" alt="GPUMDkit Logo">
 </a><br>
-<a href="https://github.com/zhyan0603/GPUMDkit"><img src="https://img.shields.io/badge/version-1.3.6-brightgreen" alt="Version"></a>
+<a href="https://github.com/zhyan0603/GPUMDkit"><img src="https://img.shields.io/badge/version-1.3.8-brightgreen" alt="Version"></a>
 <a href="https://github.com/zhyan0603/GPUMDkit/blob/main/LICENCE"><img src="https://img.shields.io/badge/license-GPL--3.0-blue" alt="License"></a>
 <a href="https://github.com/zhyan0603/GPUMDkit/stargazers"><img src="https://img.shields.io/github/stars/zhyan0603/GPUMDkit?style=social" alt="Stars"></a>
 <img src="https://img.shields.io/github/languages/code-size/zhyan0603/GPUMDkit" alt="Code Size">

--- a/Scripts/format_conversion/cif2exyz.py
+++ b/Scripts/format_conversion/cif2exyz.py
@@ -1,0 +1,42 @@
+"""
+Convert CIF file to VASP POSCAR format using ASE.
+Usage:
+    python cif2exyz.py input.cif model.xyz
+    Author: Boyi Situ (situboyi@westlake.edu.cn)
+    Date: 2025-08-21
+"""
+
+import sys
+from ase.io import read, write
+
+# Check command line arguments
+if len(sys.argv) != 3:
+    print(" Usage: python cif2exyz.py input.cif output.xyz")
+    sys.exit(1)
+
+# Read input and output file paths
+cif_file = sys.argv[1]
+xyz_file = sys.argv[2]
+
+# Read CIF structure
+try:
+    atoms = read(cif_file, format='cif')
+except Exception as e:
+    print(f" Error reading CIF file {cif_file}: {e}")
+    sys.exit(1)
+
+# Remove specified fields from atoms.info
+fields_to_remove = ['spacegroup', 'unit_cell', 'occupancy']
+for field in fields_to_remove:
+    atoms.info.pop(field, None)
+
+if hasattr(atoms, 'arrays') and 'spacegroup_kinds' in atoms.arrays:
+    del atoms.arrays['spacegroup_kinds']
+
+# Write exerts format
+try:
+    write(xyz_file, atoms, format='extxyz')
+    print(f" Converted {cif_file} to {xyz_file}")
+except Exception as e:
+    print(f" Error writing extxyz file {xyz_file}: {e}")
+    sys.exit(1)

--- a/Scripts/format_conversion/cif2pos.py
+++ b/Scripts/format_conversion/cif2pos.py
@@ -1,0 +1,27 @@
+"""
+Convert CIF file to VASP POSCAR format using ASE.
+Usage:
+    python cif2pos.py input.cif output.vasp
+    Author: Boyi Situ (situboyi@westlake.edu.cn)
+    Date: 2025-08-21
+"""
+
+import sys
+from ase.io import read, write
+
+# Check command line arguments
+if len(sys.argv) != 3:
+    print(" Usage: python cif2poscar.py input.cif output.vasp")
+    sys.exit(1)
+
+# Read input and output file paths
+cif_file = sys.argv[1]
+poscar_file = sys.argv[2]
+
+# Read CIF structure
+atoms = read(cif_file)
+
+# Write POSCAR format
+write(poscar_file, atoms, format='vasp', vasp5=True, direct=True)
+
+print(f" Converted {cif_file} to {poscar_file}")

--- a/Scripts/utils/completion.sh
+++ b/Scripts/utils/completion.sh
@@ -13,7 +13,7 @@ _gpumdkit_completions() {
     prev="${COMP_WORDS[COMP_CWORD-1]}" # Previous word
 
     # List of primary options (extracted from gpumdkit.sh)
-    local opts="-h -update -U -help -clean -time -plt -calc -range -out2xyz -outcar2exyz -cast2xyz -castep2exyz -cp2k2xyz -cp2k2exyz -mtp2xyz -mtp2exyz -pos2exyz -exyz2pos -pos2lmp -lmp2exyz -addgroup -addlabel -addweight -max_rmse -get_max_rmse_xyz -min_dist -min_dist_pbc -filter_dist -filter_dist_pbc -filter_box -filter_value -get_frame -clear_xyz -clean_xyz -get_volume -analyze_comp"
+    local opts="-h -update -U -help -clean -time -plt -calc -range -out2xyz -outcar2exyz -cast2xyz -castep2exyz -cp2k2xyz -cp2k2exyz -mtp2xyz -mtp2exyz -pos2exyz -cif2pos -cif2exyz -exyz2pos -pos2lmp -lmp2exyz -addgroup -addlabel -addweight -max_rmse -get_max_rmse_xyz -min_dist -min_dist_pbc -filter_dist -filter_dist_pbc -filter_box -filter_value -get_frame -clear_xyz -clean_xyz -get_volume -analyze_comp"
 
     # Provide secondary completion based on the previous word
     case "$prev" in

--- a/gpumdkit.sh
+++ b/gpumdkit.sh
@@ -12,7 +12,7 @@ if [ -z "$GPUMD_path" ] || [ -z "$GPUMDkit_path" ]; then
     exit 1
 fi
 
-VERSION="1.3.7 (dev) (2025-08-15)"
+VERSION="1.3.8 (dev) (2025-08-21)"
 
 #--------------------- function 1 format conversion ----------------------
 # These functions are used to convert the format of the files
@@ -151,7 +151,7 @@ echo " 000) Return to the main menu"
 echo " ------------>>"
 echo " Input the function number:"
 
-arry_num_choice=("000" "101" "102" "103" "104" ) 
+arry_num_choice=("000" "101" "102" "103" "104" "105") 
 read -p " " num_choice
 while ! echo "${arry_num_choice[@]}" | grep -wq "$num_choice" 
 do
@@ -841,6 +841,7 @@ function help_info_table(){
     echo "+======================================== Conversions =============================================+"
     echo "| -outcar2exyz   Convert OUTCAR to extxyz       | -pos2exyz     Convert POSCAR to extxyz           |"
     echo "| -castep2exyz   Convert castep to extxyz       | -pos2lmp      Convert POSCAR to LAMMPS           |"
+    echo "| -cif2pos       Convert cif to POSCAR          | -cif2exyz     Convert cif to extxyz              |"
     echo "| -cp2k2exyz     Convert cp2k output to extxyz  | -lmp2exyz     Convert LAMMPS-dump to extxyz      |"
     echo "| -addgroup      Add group label                | -addweight    Add weight to the struct in extxyz |"
     echo "| Developing...                                 | Developing...                                    |"
@@ -1177,6 +1178,31 @@ if [ ! -z "$1" ]; then
                 echo " Code path: ${GPUMDkit_path}/Scripts/format_conversion/pos2exyz.py"
             fi
             ;;
+
+        -cif2pos)
+            if [ ! -z "$2" ] && [ ! -z "$3" ] && [ "$2" != "-h" ] ; then
+                echo " Calling script by Boyi SITU "
+                echo " Code path: ${GPUMDkit_path}/Scripts/format_conversion/cif2pos.py"
+                python ${GPUMDkit_path}/Scripts/format_conversion/cif2pos.py $2 $3
+            else
+                echo " Usage: -cif2pos input.cif POSCAR.vasp"
+                echo " See the source code of cif2pos.py for more details"
+                echo " Code path: ${GPUMDkit_path}/Scripts/format_conversion/cif2pos.py"
+            fi
+            ;;
+
+        -cif2exyz)
+            if [ ! -z "$2" ] && [ ! -z "$3" ] && [ "$2" != "-h" ] ; then
+                echo " Calling script by Boyi SITU "
+                echo " Code path: ${GPUMDkit_path}/Scripts/format_conversion/cif2exyz.py"
+                python ${GPUMDkit_path}/Scripts/format_conversion/cif2exyz.py $2 $3
+            else
+                echo " Usage: -cif2exyz input.cif model.xyz"
+                echo " See the source code of cif2exyz.py for more details"
+                echo " Code path: ${GPUMDkit_path}/Scripts/format_conversion/cif2exyz.py"
+            fi
+            ;;
+
 
         -exyz2pos)
             if [ ! -z "$2" ] && [ "$2" != "-h" ] ; then


### PR DESCRIPTION
This pull request adds support for converting CIF files to both POSCAR and extxyz formats, updates the command-line interface and documentation to reflect these new features, and bumps the version to 1.3.8. The main changes include new conversion scripts, CLI integration, and updates to help information and autocompletion.

**New format conversion features:**
* Added new scripts `cif2pos.py` and `cif2exyz.py` for converting CIF files to VASP POSCAR and extxyz formats, respectively. These scripts use ASE for conversion and provide command-line usage instructions. [[1]](diffhunk://#diff-8a0860d30a72bf0071a2f2308845289658e0557c8617d3a33a0bfcb133adde0cR1-R27) [[2]](diffhunk://#diff-30d3d80af897b6bbcefb2d9eefde615e6bbc52af2d16ba2b79c580f83feb08a4R1-R42)
* Integrated `-cif2pos` and `-cif2exyz` options into the main `gpumdkit.sh` command-line interface, enabling users to call the new conversion scripts directly from the toolkit.

**Command-line improvements:**
* Updated the help table in `gpumdkit.sh` and the shell autocompletion script to include the new `-cif2pos` and `-cif2exyz` options, making them discoverable and easier to use. [[1]](diffhunk://#diff-495d99f601815741384d8018da45abb96f2f308c9cf48ca78a7d9f579b2cf07aR844) [[2]](diffhunk://#diff-d41cf2d3bdef08da5440ec391628e3f0cacd63c1f0f50fd21b8a4c89cd431e1cL16-R16)
* Added the new option numbers to the main menu selection array in `gpumdkit.sh`.

**Documentation and versioning:**
* Updated the version in both `gpumdkit.sh` and the `README.md` badge to 1.3.8 to reflect the new release. [[1]](diffhunk://#diff-495d99f601815741384d8018da45abb96f2f308c9cf48ca78a7d9f579b2cf07aL15-R15) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5)