### PR TITLE
add notes for -plt charge

### DIFF
--- a/gpumdkit.sh
+++ b/gpumdkit.sh
@@ -950,6 +950,12 @@ if [ ! -z "$1" ]; then
                         python ${GPUMDkit_path}/Scripts/plt_scripts/plt_descriptors.py $3 ${@:4}
                         ;;     
                     "charge")
+                        echo " +----------------------------------------------------------+"
+                        echo " | Please ensure you are using full batch training process. |"
+                        echo " | If not, run the prediction step before plotting to avoid |"
+                        echo " | inconsistencies in the atomic order between the training |"
+                        echo " | set and charge_train.out.                                |"
+                        echo " +----------------------------------------------------------+"
                         python ${GPUMDkit_path}/Scripts/plt_scripts/plt_charge.py $3
                         ;;
                     "lr"|"learning_rate")


### PR DESCRIPTION
This pull request adds a user guidance message to the `charge` plotting option in `gpumdkit.sh`. The message reminds users to ensure consistency between training and prediction steps, helping prevent issues with atomic order in charge plots.

User experience improvements:

* Added a clear warning message before running `plt_charge.py` to advise users to use full batch training or run prediction before plotting, preventing inconsistencies in atomic ordering between `charge_train.out` and the training set.